### PR TITLE
Fix issues with EU-based Sentry accounts, and with webhook failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
       },
       "settings": {
         "region": {
-          "title": "Sentry server region",
-          "description": "The region your Sentry account is hosted in (e.g. US/EU)",
+          "title": "Sentry data storage location",
+          "description": "Your Sentry account's data storage location (United States or European Union).",
           "type": "string",
           "default": "us",
           "options": [

--- a/package.json
+++ b/package.json
@@ -58,6 +58,35 @@
             "Requirement"
           ]
         }
+      },
+      "settings": {
+        "region": {
+          "title": "Sentry server region",
+          "description": "The region your Sentry account is hosted in (e.g. US/EU)",
+          "type": "string",
+          "default": "us",
+          "options": [
+            {
+              "label": "US",
+              "value": "us"
+            },
+            {
+              "label": "EU",
+              "value": "eu"
+            }
+          ],
+          "scope": [
+            "account"
+          ]
+        },
+        "team": {
+          "title": "Aha! webhook team",
+          "description": "The reference prefix of the Aha! team where features will be created from incoming Sentry webhook issues.",
+          "type": "string",
+          "scope": [
+            "account"
+          ]
+        }
       }
     }
   },

--- a/src/helpers/WebhookMgr.ts
+++ b/src/helpers/WebhookMgr.ts
@@ -33,13 +33,19 @@ export class WebhookMgr {
       const issue_id = this.filterPayload("issue_id");
       const record = new aha.models["Feature"]();
       const title = this.filterPayload("title");
+
+      const team = await aha.models.Project.select("id").find(
+        aha.settings.get(`${this.identifier}.team`) as string
+      );
+
+      record.team = team;
       record.name = title;
       record.description = `
       <p>
         <pre>${title}</pre>
       </p>
       <p>
-        <a href='${this.filterPayload("issue_url")}}'>View in Sentry</a>
+        <a href='${this.filterPayload("web_url")}'>View in Sentry</a>
       </p>` as any;
       record.setExtensionField(this.identifier, "issue_id", issue_id);
       record.setExtensionField(this.identifier, "isSentry", true);
@@ -61,13 +67,13 @@ export class WebhookMgr {
     const data = keys.reduce((acc, key) => {
       switch (key) {
         case "api_url":
-          acc[key] = this.getProp(this.payload, `${this.resource}.url`);
+          acc[key] = this.getProp(this.payload, `data.${this.resource}.url`);
           break;
         case "issue_id":
-          acc[key] = this.getProp(this.payload, `issue.id`);
+          acc[key] = this.getProp(this.payload, `data.issue.id`);
           break;
         default:
-          acc[key] = this.getProp(this.payload, `${this.resource}.${key}`);
+          acc[key] = this.getProp(this.payload, `data.${this.resource}.${key}`);
           break;
       }
       return acc;

--- a/src/helpers/axios.ts
+++ b/src/helpers/axios.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from "axios";
-import { API_URL } from "./config";
+import { API_URL_MAPPING, DEFAULT_REGION, IDENTIFIER } from "./config";
 
 /**
  * Create Axios Instance
@@ -11,8 +11,9 @@ const createAxiosInstance = (accessToken): AxiosInstance => {
   /**
    * Create Axios Instance
    */
+  const region = (aha.settings.get(`${IDENTIFIER}.region`) || DEFAULT_REGION) as string;
   const axiosInstance = axios.create({
-    baseURL: `${API_URL}`,
+    baseURL: `${API_URL_MAPPING[region]}`,
     headers: {
       authorization: `Bearer ${accessToken}`,
     },

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1,7 +1,15 @@
 /**
  * Sentry API EndPoint
  */
-export const API_URL = "https://sentry.io/api/0";
+const EU_API_URL = "https://de.sentry.io/api/0";
+const US_API_URL = "https://sentry.io/api/0";
+
+export const DEFAULT_REGION = "us";
+
+export const API_URL_MAPPING = {
+  eu: EU_API_URL,
+  us: US_API_URL,
+};
 
 /**
  * Pagination Limit


### PR DESCRIPTION
EU-based accounts use a different URL - adds a setting to toggle to the EU region.

Additionally, adds a setting to select a team prefix, as the target team when creating features from incoming webhook messages, as either a team or release is required to create a feature.

<img width="987" height="371" alt="Screenshot 2025-09-24 at 2 41 15 PM" src="https://github.com/user-attachments/assets/ba42409d-8bcf-4148-8dfc-87e85a6b50ce" />
