### PR TITLE
Update CSP sources to include DE Sentry server

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "ahaExtension": {
     "cspSources": [
-      "https://sentry.io"
+      "https://sentry.io",
+      "https://de.sentry.io"
     ],
     "contributes": {
       "importers": {


### PR DESCRIPTION
This was missed in the previous update - we need to ensure the `de.sentry.io` source is a valid CSP source for the extension